### PR TITLE
Fix wikiwand not rendering any formulas.

### DIFF
--- a/content-scripts/mediawiki.css
+++ b/content-scripts/mediawiki.css
@@ -12,6 +12,7 @@
     width: auto;
     height: auto;
     opacity: 1;
+    display: inherit !important;
 }
 /* Support where MediaWiki lazy loaded images */
 .mwe-math-mathml-inline ~ .lazy-image-placeholder,


### PR DESCRIPTION
Hello @fred-wang 

I'm quite a fan of your work with MathML!

This PR aims to fix at least Wikiwand rendering of MathML formulas.
Referring to 

> Do you have an example? https://www.wikiwand.com/en/Fourier_transform renders with HTML/CSS for me and looks bad. By default, Wikipedia provide SVG + MathML hidden via CSS (but still exposed to screen readers) so it's easy to switch to native MathML. You should probably made a request to them and I could easily adapt the CSS stylesheet. Implementing exclusion list would be more difficult for me as I'll have to check how to do that for WebExtensions and don't have much time.

from https://github.com/fred-wang/webextension-native-mathml/issues/2

Before, the formulas was kept completely hidden. I have tested this solution both on Wikiwand,  Wikipedia, various MediaWiki (that remains untouched) and Wikizero.

For references:
https://en.wikipedia.org/wiki/Fourier_transform
https://www.wikiwand.com/en/Fourier_transform
https://www.wikizero.com/en/Fourier_transform