### PR TITLE
Even more forcibly show MathML in VisualEditor

### DIFF
--- a/content-scripts/mediawiki.css
+++ b/content-scripts/mediawiki.css
@@ -14,6 +14,10 @@
     opacity: 1 !important;
     display: inherit !important;
 }
+body.mediawiki .ve-ce-mwLatexNode .mwe-math-mathml-a11y {
+    /* override https://phabricator.wikimedia.org/diffusion/EMAT/browse/master/modules/ve-math/ve.ce.MWLatexNode.css */
+    display: inherit !important;
+}
 /* Support where MediaWiki lazy loaded images */
 .mwe-math-mathml-inline ~ .lazy-image-placeholder,
 .mwe-math-mathml-display ~ .lazy-image-placeholder,


### PR DESCRIPTION
Since Firefox supports `-webkit-device-pixel-ratio` (v63+, October 2018), the workaround in https://phabricator.wikimedia.org/diffusion/EMAT/browse/master/modules/ve-math/ve.ce.MWLatexNode.css overrides our rule, and no formula appears in VisualEditor. Try harder to get our rule apply.